### PR TITLE
Feat/draft access control

### DIFF
--- a/.github/workflows/draft-from-issue.yml
+++ b/.github/workflows/draft-from-issue.yml
@@ -1,0 +1,132 @@
+name: Create Draft Packet from Issue
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  create-draft:
+    if: contains(github.event.issue.labels.*.name, 'hands-on-lab')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Parse issue and create draft packet
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const body = issue.body || '';
+
+            // Parse GitHub Issue Form fields (### Label\n\nValue format)
+            function parseField(label) {
+              const regex = new RegExp(`### ${label}\\s*\\n\\n([\\s\\S]*?)(?=\\n### |$)`);
+              const match = body.match(regex);
+              return match ? match[1].trim() : '';
+            }
+
+            function parseCSV(label) {
+              const val = parseField(label);
+              return val ? val.split(',').map(s => s.trim()).filter(Boolean) : [];
+            }
+
+            const title = parseField('Lab Title');
+            const description = parseField('Description');
+            const maintainer = parseField('Maintainer').replace(/^@/, '');
+            const discoverability = parseField('Discoverability Level') || 'Internal';
+            const technicalDomain = parseCSV('Technical Domain Tags');
+            const language = parseCSV('Language Tags');
+
+            if (!title) {
+              core.setFailed('Could not parse Lab Title from issue body');
+              return;
+            }
+
+            // Generate kebab-case ID from title
+            const id = title.toLowerCase()
+              .replace(/[^a-z0-9\s-]/g, '')
+              .replace(/\s+/g, '-')
+              .replace(/-+/g, '-')
+              .replace(/^-|-$/g, '');
+
+            const today = new Date().toISOString().split('T')[0];
+
+            const packet = {
+              id: id,
+              title: title,
+              packetType: 'Hands On Lab',
+              issueTemplate: 'propose-hands-on-lab.yml',
+              description: description,
+              maintainer: maintainer,
+              created: today,
+              updated: today,
+              issueNumber: issue.number,
+              publishState: 'Draft',
+              discoverability: discoverability,
+              tags: {
+                industry: [],
+                productLine: ['Devin'],
+                technicalDomain: technicalDomain,
+                language: language,
+                custom: ['hands-on-lab']
+              },
+              contentGroups: [],
+              resources: {}
+            };
+
+            const fs = require('fs');
+            const filename = `${id}.json`;
+            const packetPath = `data/packets/${filename}`;
+
+            // Write packet JSON
+            fs.writeFileSync(packetPath, JSON.stringify(packet, null, 2) + '\n');
+
+            // Update index.json
+            const indexPath = 'data/packets/index.json';
+            const index = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+            if (!index.includes(filename)) {
+              index.push(filename);
+              fs.writeFileSync(indexPath, JSON.stringify(index, null, 2) + '\n');
+            }
+
+            // Export for later steps
+            core.exportVariable('PACKET_FILENAME', filename);
+            core.exportVariable('PACKET_TITLE', title);
+            core.exportVariable('ISSUE_NUMBER', issue.number.toString());
+
+      - name: Commit draft packet to main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/packets/
+          git commit -m "feat: add draft packet '${PACKET_TITLE}' from issue #${ISSUE_NUMBER}"
+          git push origin main
+
+      - name: Comment on issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: parseInt(process.env.ISSUE_NUMBER),
+              body: `Draft packet **${process.env.PACKET_TITLE}** has been created and is now visible in the [Field Kit draft view](https://${context.repo.owner}.github.io/${context.repo.repo}/?token=drafts).\n\nFile: \`data/packets/${process.env.PACKET_FILENAME}\``
+            });
+
+      - name: Add draft label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: parseInt(process.env.ISSUE_NUMBER),
+              labels: ['draft-created']
+            });

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -780,6 +780,31 @@ body {
 .site-footer a { color: var(--color-accent); text-decoration: none; }
 .site-footer a:hover { color: #2d5ab8; }
 
+/* ===== Draft Approval Actions ===== */
+.draft-actions {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  margin-top: 0.6rem;
+}
+
+.btn-approve {
+  background: var(--color-success);
+  color: #ffffff;
+}
+.btn-approve:hover { background: #1aab88; }
+
+.btn-reject {
+  background: var(--color-danger);
+  color: #ffffff;
+}
+.btn-reject:hover { background: #d04233; }
+
+.btn-sm {
+  padding: 0.3rem 0.6rem;
+  font-size: 0.72rem;
+}
+
 @media (max-width: 900px) {
   .content-area { grid-template-columns: 1fr; }
   .sidebar { position: static; display: flex; gap: 0.6rem; flex-wrap: wrap; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -4,7 +4,7 @@
   'use strict';
 
   // Draft access: only viewers with ?token=<DRAFT_TOKEN> can see Draft packets
-  const DRAFT_TOKEN = 'fieldkit-drafts-2026';
+  const DRAFT_TOKEN = 'drafts';
   const isDraftViewer = new URLSearchParams(window.location.search).get('token') === DRAFT_TOKEN;
 
   let allPackets = [];

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -3,6 +3,10 @@
 (function () {
   'use strict';
 
+  // Draft access: only viewers with ?token=<DRAFT_TOKEN> can see Draft packets
+  const DRAFT_TOKEN = 'fieldkit-drafts-2026';
+  const isDraftViewer = new URLSearchParams(window.location.search).get('token') === DRAFT_TOKEN;
+
   let allPackets = [];
   let filteredPackets = [];
   let activeFilters = {
@@ -38,6 +42,11 @@
   document.addEventListener('DOMContentLoaded', async () => {
     cacheDom();
     bindEvents();
+    // Hide Draft filter option for non-token visitors
+    if (!isDraftViewer) {
+      const draftOpt = $stateFilter.querySelector('option[value="Draft"]');
+      if (draftOpt) draftOpt.remove();
+    }
     await loadPackets();
     buildSidebar();
     buildProposeDropdown();
@@ -150,6 +159,8 @@
     const counts = { type: {}, industry: {}, domain: {}, allTags: {} };
 
     allPackets.forEach(p => {
+      // Exclude Draft packets from sidebar counts for non-token visitors
+      if (!isDraftViewer && p.publishState === 'Draft') return;
       if (p.packetType) counts.type[p.packetType] = (counts.type[p.packetType] || 0) + 1;
       (p.tags.industry || []).forEach(t => { counts.industry[t] = (counts.industry[t] || 0) + 1; });
       (p.tags.technicalDomain || []).forEach(t => { counts.domain[t] = (counts.domain[t] || 0) + 1; });
@@ -219,6 +230,8 @@
     const q = activeFilters.search.toLowerCase();
 
     filteredPackets = allPackets.filter(p => {
+      // Hide Draft packets from non-token visitors
+      if (!isDraftViewer && p.publishState === 'Draft') return false;
       if (activeFilters.publishState && p.publishState !== activeFilters.publishState) return false;
       if (activeFilters.discoverability && p.discoverability !== activeFilters.discoverability) return false;
       if (activeFilters.packetType && p.packetType !== activeFilters.packetType) return false;
@@ -357,7 +370,7 @@
   }
 
   function renderResultsSummary() {
-    const total = allPackets.length;
+    const total = isDraftViewer ? allPackets.length : allPackets.filter(p => p.publishState !== 'Draft').length;
     const shown = filteredPackets.length;
     $resultsSummary.textContent = shown === total
       ? `Showing all ${total} packet${total !== 1 ? 's' : ''}`
@@ -560,8 +573,11 @@
   }
 
   function renderResourceSection(title, resources) {
+    // Filter out Draft resources for non-token visitors
+    const visibleResources = isDraftViewer ? resources : resources.filter(r => r.state !== 'Draft');
+    if (visibleResources.length === 0) return '';
     let html = `<div class="modal-section"><h3>${esc(title)}</h3><ul class="resource-list">`;
-    resources.forEach(r => {
+    visibleResources.forEach(r => {
       const icon = RESOURCE_ICONS[r.type] || RESOURCE_ICONS['other'];
       const accessClass = (r.access || 'public');
       const isDraft = r.state === 'Draft';

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -38,6 +38,26 @@
     'other': '\u{1F4CE}'
   };
 
+  const GITHUB_REPO = 'Devin-Samples/field-kit';
+  const GITHUB_BRANCH = 'main';
+
+  function approveUrl(packet) {
+    // Link to edit the packet file on GitHub — user changes publishState to Published and commits
+    const filename = packet.id + '.json';
+    return `https://github.com/${GITHUB_REPO}/edit/${GITHUB_BRANCH}/data/packets/${filename}`;
+  }
+
+  function rejectUrl(packet) {
+    // Link to delete the packet file on GitHub — creates a commit/PR removing it
+    const filename = packet.id + '.json';
+    return `https://github.com/${GITHUB_REPO}/delete/${GITHUB_BRANCH}/data/packets/${filename}`;
+  }
+
+  function issueUrl(packet) {
+    if (!packet.issueNumber) return null;
+    return `https://github.com/${GITHUB_REPO}/issues/${packet.issueNumber}`;
+  }
+
   // --- Boot ---
   document.addEventListener('DOMContentLoaded', async () => {
     cacheDom();
@@ -305,6 +325,12 @@
             <span>\u{1F464} ${esc(p.maintainer || 'Unknown')}</span>
             <span>\u{1F4C5} ${esc(p.updated || p.created || '')}</span>
           </div>
+          ${isDraftViewer && p.publishState === 'Draft' ? `
+          <div class="draft-actions">
+            <a href="${esc(approveUrl(p))}" target="_blank" rel="noopener" class="btn btn-approve" onclick="event.stopPropagation()">Approve</a>
+            <a href="${esc(rejectUrl(p))}" target="_blank" rel="noopener" class="btn btn-reject" onclick="event.stopPropagation()">Reject</a>
+            ${p.issueNumber ? `<a href="${esc(issueUrl(p))}" target="_blank" rel="noopener" class="btn btn-outline btn-sm" onclick="event.stopPropagation()">#${p.issueNumber}</a>` : ''}
+          </div>` : ''}
         </div>`;
     }).join('');
 
@@ -400,6 +426,12 @@
             <span class="badge ${stateBadge}">${esc(packet.publishState)}</span>
             <span class="badge ${discBadge}">${esc(packet.discoverability)}</span>
           </div>
+          ${isDraftViewer && packet.publishState === 'Draft' ? `
+          <div class="draft-actions" style="margin-top:0.6rem">
+            <a href="${esc(approveUrl(packet))}" target="_blank" rel="noopener" class="btn btn-approve">Approve</a>
+            <a href="${esc(rejectUrl(packet))}" target="_blank" rel="noopener" class="btn btn-reject">Reject</a>
+            ${packet.issueNumber ? `<a href="${esc(issueUrl(packet))}" target="_blank" rel="noopener" class="btn btn-outline btn-sm">View Issue #${packet.issueNumber}</a>` : ''}
+          </div>` : ''}
         </div>
         <button class="modal-close" id="modal-close-btn">&times;</button>
       </div>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -42,10 +42,13 @@
   document.addEventListener('DOMContentLoaded', async () => {
     cacheDom();
     bindEvents();
-    // Hide Draft filter option for non-token visitors
+    // Hide Draft filter option for non-token visitors; default to Draft if token present
     if (!isDraftViewer) {
       const draftOpt = $stateFilter.querySelector('option[value="Draft"]');
       if (draftOpt) draftOpt.remove();
+    } else {
+      $stateFilter.value = 'Draft';
+      activeFilters.publishState = 'Draft';
     }
     await loadPackets();
     buildSidebar();

--- a/data/schema.json
+++ b/data/schema.json
@@ -48,6 +48,10 @@
       "type": "string",
       "format": "date"
     },
+    "issueNumber": {
+      "type": "integer",
+      "description": "GitHub issue number that originated this packet (set automatically by the draft workflow)"
+    },
     "publishState": {
       "type": "string",
       "enum": [


### PR DESCRIPTION
Summary

  • Draft access control: Draft packets and draft-state resources are hidden from all visitors by default. Only viewers with ?token=drafts in the URL can see
  draft content. The "Draft" option is removed from the State filter dropdown for normal visitors.
  • Draft-first viewing: When accessing via the token, the State filter defaults to "Draft" so draft content is immediately visible.
  • Automated draft creation: A GitHub Action triggers when an issue is opened with the hands-on-lab label, parses the issue form fields, generates a draft packet
  JSON file, and commits it directly to main — no PR required. It also comments on the issue with a link to the draft view.
  • Approve/Reject workflow: Draft packets in the ?token=drafts view display Approve and Reject buttons on both the card and the modal. Approve opens the packet
  JSON in GitHub's file editor to change publishState to "Published". Reject opens GitHub's file delete page to remove the packet. Both actions create a PR for
  review.
  • Issue linking: Added issueNumber field to the packet schema. When present, a link to the originating GitHub issue is shown alongside the Approve/Reject
  buttons.

Test plan

  • [ ] Visit the site without ?token=drafts — verify no draft content is visible and the Draft filter option is absent
  • [ ] Visit with ?token=drafts — verify drafts are visible and the State filter defaults to Draft
  • [ ] Open a GitHub issue using the "Propose a Hands On Lab" template — verify the Action creates a draft packet JSON on main and comments on the issue
  • [ ] In draft view, verify Approve button links to the correct file edit page on GitHub
  • [ ] In draft view, verify Reject button links to the correct file delete page on GitHub
  • [ ] Verify the issue link button appears when issueNumber is set on a packet

<!-- devin-review-badge-begin -->

---

<a href="https://partner-workshops.devinenterprise.com/review/devin-samples/field-kit/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
